### PR TITLE
Implement endpoints for enrollment requests related logic

### DIFF
--- a/thryve-backend/src/main/java/bg/sofia/uni/fmi/webjava/backend/controller/EnrollmentRequestController.java
+++ b/thryve-backend/src/main/java/bg/sofia/uni/fmi/webjava/backend/controller/EnrollmentRequestController.java
@@ -1,0 +1,100 @@
+package bg.sofia.uni.fmi.webjava.backend.controller;
+
+import bg.sofia.uni.fmi.webjava.backend.model.dto.EntityModificationResponse;
+import bg.sofia.uni.fmi.webjava.backend.model.dto.enrollment.request.EnrollmentRequestResponseDto;
+import bg.sofia.uni.fmi.webjava.backend.service.EnrollmentRequestService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class EnrollmentRequestController {
+
+    private static final String ENROLLMENT_REQUEST_CREATED_MESSAGE = "Enrollment request created successfully!";
+    private static final String ENROLLMENT_REQUEST_UPDATED_MESSAGE = "Enrollment request updated successfully!";
+    private static final String ENROLLMENT_REQUEST_DELETED_MESSAGE = "Enrollment request deleted successfully!";
+
+    private final EnrollmentRequestService enrollmentRequestService;
+
+    @GetMapping("/courses/{courseId}/enrollment-requests")
+    public ResponseEntity<Page<EnrollmentRequestResponseDto>> getEnrollmentRequestsByCourseId(
+        @PathVariable("courseId") UUID courseId,
+        @RequestParam(defaultValue = "0") int pageNumber,
+        @RequestParam(defaultValue = "10") int pageSize,
+        @RequestParam(defaultValue = "id") String sortBy,
+        @RequestParam(defaultValue = "ASC") String direction
+    ) {
+        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.fromOptionalString(direction).orElse(Sort.Direction.ASC), sortBy));
+        Page<EnrollmentRequestResponseDto> enrollmentRequests = enrollmentRequestService.getEnrollmentsByCourseId(courseId, pageable);
+        return ResponseEntity.ok(enrollmentRequests);
+    }
+
+    @GetMapping("/users/{userId}/enrollment-requests")
+    public ResponseEntity<Page<EnrollmentRequestResponseDto>> getEnrollmentRequestsByUserId(
+        @PathVariable("userId") UUID courseId,
+        @RequestParam(defaultValue = "0") int pageNumber,
+        @RequestParam(defaultValue = "10") int pageSize,
+        @RequestParam(defaultValue = "id") String sortBy,
+        @RequestParam(defaultValue = "ASC") String direction
+    ) {
+        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.fromOptionalString(direction).orElse(Sort.Direction.ASC), sortBy));
+        Page<EnrollmentRequestResponseDto> enrollmentRequests = enrollmentRequestService.getEnrollmentsByUserId(courseId, pageable);
+        return ResponseEntity.ok(enrollmentRequests);
+    }
+
+    @PostMapping("/courses/{courseId}/enrollment-requests")
+    public ResponseEntity<EntityModificationResponse<EnrollmentRequestResponseDto>> createEnrollmentRequest(
+        @PathVariable("courseId") UUID courseId,
+        @RequestParam("userId") UUID userId
+    ) {
+        EnrollmentRequestResponseDto response = enrollmentRequestService.createEnrollmentRequest(courseId, userId);
+        return ResponseEntity.ok(
+            new EntityModificationResponse<>(ENROLLMENT_REQUEST_CREATED_MESSAGE, response)
+        );
+    }
+
+    @PostMapping("/enrollment-requests/{id}/accept")
+    public ResponseEntity<EntityModificationResponse<EnrollmentRequestResponseDto>> updateEnrollmentRequestById(
+        @PathVariable UUID id
+    ) {
+        EnrollmentRequestResponseDto response = enrollmentRequestService.acceptEnrollmentRequestById(id);
+        return ResponseEntity.ok(
+            new EntityModificationResponse<>(ENROLLMENT_REQUEST_UPDATED_MESSAGE, response)
+        );
+    }
+
+    @PostMapping("/enrollment-requests/{id}/reject")
+    public ResponseEntity<EntityModificationResponse<EnrollmentRequestResponseDto>> rejectEnrollmentRequestById(
+        @PathVariable UUID id
+    ) {
+        EnrollmentRequestResponseDto response = enrollmentRequestService.rejectEnrollmentRequestById(id);
+        return ResponseEntity.ok(
+            new EntityModificationResponse<>(ENROLLMENT_REQUEST_UPDATED_MESSAGE, response)
+        );
+    }
+
+    @DeleteMapping("/enrollment-requests/{id}")
+    public ResponseEntity<EntityModificationResponse<EnrollmentRequestResponseDto>> deleteEnrollmentRequestById(
+        @PathVariable UUID id
+    ) {
+        EnrollmentRequestResponseDto response = enrollmentRequestService.deleteEnrollmentRequestById(id);
+        return ResponseEntity.ok(
+            new EntityModificationResponse<>(ENROLLMENT_REQUEST_DELETED_MESSAGE, response)
+        );
+    }
+
+}

--- a/thryve-backend/src/main/java/bg/sofia/uni/fmi/webjava/backend/exception/EnrollmentRequestAlreadyFinalizedException.java
+++ b/thryve-backend/src/main/java/bg/sofia/uni/fmi/webjava/backend/exception/EnrollmentRequestAlreadyFinalizedException.java
@@ -1,0 +1,9 @@
+package bg.sofia.uni.fmi.webjava.backend.exception;
+
+public class EnrollmentRequestAlreadyFinalizedException extends RuntimeException {
+
+    public EnrollmentRequestAlreadyFinalizedException(String message) {
+        super(message);
+    }
+
+}

--- a/thryve-backend/src/main/java/bg/sofia/uni/fmi/webjava/backend/exception/GlobalExceptionHandler.java
+++ b/thryve-backend/src/main/java/bg/sofia/uni/fmi/webjava/backend/exception/GlobalExceptionHandler.java
@@ -78,6 +78,15 @@ public class GlobalExceptionHandler {
             .body(new MessageResponse(ex.getMessage()));
     }
 
+    @ExceptionHandler(EnrollmentRequestAlreadyFinalizedException.class)
+    public ResponseEntity<MessageResponse> handleExceptionsWithBadRequest(
+        EnrollmentRequestAlreadyFinalizedException ex
+    ) {
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(new MessageResponse(ex.getMessage()));
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<MessageResponse> handleUnexpectedException(Exception ex) {
         return ResponseEntity

--- a/thryve-backend/src/main/java/bg/sofia/uni/fmi/webjava/backend/mapper/EnrollmentRequestDtoMapper.java
+++ b/thryve-backend/src/main/java/bg/sofia/uni/fmi/webjava/backend/mapper/EnrollmentRequestDtoMapper.java
@@ -1,0 +1,12 @@
+package bg.sofia.uni.fmi.webjava.backend.mapper;
+
+import bg.sofia.uni.fmi.webjava.backend.model.dto.enrollment.request.EnrollmentRequestResponseDto;
+import bg.sofia.uni.fmi.webjava.backend.model.entity.EnrollmentRequest;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring", uses = {UserDtoMapper.class, CourseDtoMapper.class})
+public interface EnrollmentRequestDtoMapper {
+
+    EnrollmentRequestResponseDto mapToResponseDto(EnrollmentRequest enrollmentRequest);
+
+}

--- a/thryve-backend/src/main/java/bg/sofia/uni/fmi/webjava/backend/model/dto/enrollment/request/EnrollmentRequestResponseDto.java
+++ b/thryve-backend/src/main/java/bg/sofia/uni/fmi/webjava/backend/model/dto/enrollment/request/EnrollmentRequestResponseDto.java
@@ -1,0 +1,20 @@
+package bg.sofia.uni.fmi.webjava.backend.model.dto.enrollment.request;
+
+import bg.sofia.uni.fmi.webjava.backend.model.dto.course.CoursePreviewDto;
+import bg.sofia.uni.fmi.webjava.backend.model.dto.user.UserResponseDto;
+import bg.sofia.uni.fmi.webjava.backend.model.entity.EnrollmentState;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+public class EnrollmentRequestResponseDto {
+
+    private UUID id;
+    private UserResponseDto user;
+    private CoursePreviewDto course;
+    private EnrollmentState state;
+    
+}

--- a/thryve-backend/src/main/java/bg/sofia/uni/fmi/webjava/backend/model/entity/AssignmentSubmission.java
+++ b/thryve-backend/src/main/java/bg/sofia/uni/fmi/webjava/backend/model/entity/AssignmentSubmission.java
@@ -20,9 +20,6 @@ public class AssignmentSubmission extends BaseEntity {
     @Column(name = "submission_url", unique = true)
     private String submissionUrl;
 
-    @Column(name = "submitted_at")
-    private LocalDateTime submittedAt;
-
     @Column(name = "feedback")
     private String feedback;
 

--- a/thryve-backend/src/main/java/bg/sofia/uni/fmi/webjava/backend/model/entity/BaseEntity.java
+++ b/thryve-backend/src/main/java/bg/sofia/uni/fmi/webjava/backend/model/entity/BaseEntity.java
@@ -1,12 +1,15 @@
 package bg.sofia.uni.fmi.webjava.backend.model.entity;
 
 import com.github.f4b6a3.ulid.UlidCreator;
+import jakarta.persistence.Column;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import lombok.Data;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @MappedSuperclass
@@ -17,11 +20,23 @@ public abstract class BaseEntity {
     @Id
     private UUID id;
 
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime modifiedAt;
+
     @PrePersist
     private void prePersist() {
-        if (id == null) {
-            id = UlidCreator.getUlid().toUuid();
-        }
+        id = UlidCreator.getUlid().toUuid();
+        LocalDateTime now = LocalDateTime.now();
+        createdAt = now;
+        modifiedAt = now;
+    }
+
+    @PreUpdate
+    private void preUpdate() {
+        modifiedAt = LocalDateTime.now();
     }
 
 }

--- a/thryve-backend/src/main/java/bg/sofia/uni/fmi/webjava/backend/model/entity/Enrollment.java
+++ b/thryve-backend/src/main/java/bg/sofia/uni/fmi/webjava/backend/model/entity/Enrollment.java
@@ -19,9 +19,6 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class Enrollment extends BaseEntity {
 
-    @Column(name = "enrolled_at", nullable = false)
-    private LocalDateTime enrolledAt = LocalDateTime.now();
-
     @Column(name = "type", nullable = false)
     @Enumerated(EnumType.STRING)
     private EnrollmentType enrollmentType;

--- a/thryve-backend/src/main/java/bg/sofia/uni/fmi/webjava/backend/model/entity/EnrollmentRequest.java
+++ b/thryve-backend/src/main/java/bg/sofia/uni/fmi/webjava/backend/model/entity/EnrollmentRequest.java
@@ -21,12 +21,9 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class EnrollmentRequest extends BaseEntity {
 
-    @Column(name = "requested_at", nullable = false)
-    private LocalDateTime requestedAt;
-
     @Column(name = "state", nullable = false)
     @Enumerated(EnumType.STRING)
-    private EnrollmentState state;
+    private EnrollmentState state = EnrollmentState.PENDING;
 
     @ManyToOne
     private User user;

--- a/thryve-backend/src/main/java/bg/sofia/uni/fmi/webjava/backend/model/entity/Notification.java
+++ b/thryve-backend/src/main/java/bg/sofia/uni/fmi/webjava/backend/model/entity/Notification.java
@@ -23,9 +23,6 @@ public class Notification extends BaseEntity {
     @Column(name = "text_content", columnDefinition = "TEXT", nullable = false)
     private String textContent;
 
-    @Column(name = "posted_at", nullable = false)
-    private LocalDateTime postedAt;
-
     @ManyToOne
     private User sender;
 

--- a/thryve-backend/src/main/java/bg/sofia/uni/fmi/webjava/backend/model/entity/Resource.java
+++ b/thryve-backend/src/main/java/bg/sofia/uni/fmi/webjava/backend/model/entity/Resource.java
@@ -23,9 +23,6 @@ public class Resource extends BaseEntity {
     @Column(name = "url", nullable = false)
     private String url;
 
-    @Column(name = "uploaded_at", nullable = false)
-    private LocalDateTime uploadedAt;
-
     @ManyToOne
     private Course course;
 

--- a/thryve-backend/src/main/java/bg/sofia/uni/fmi/webjava/backend/repository/EnrollmentRequestRepository.java
+++ b/thryve-backend/src/main/java/bg/sofia/uni/fmi/webjava/backend/repository/EnrollmentRequestRepository.java
@@ -1,12 +1,21 @@
 package bg.sofia.uni.fmi.webjava.backend.repository;
 
 import bg.sofia.uni.fmi.webjava.backend.model.entity.EnrollmentRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface EnrollmentRequestRepository extends JpaRepository<EnrollmentRequest, UUID> {
+
+    Page<EnrollmentRequest> findEnrollmentRequestsByCourseId(UUID courseId, Pageable pageable);
+
+    Page<EnrollmentRequest> findEnrollmentRequestsByUserId(UUID userId, Pageable pageable);
+
+    Optional<EnrollmentRequest> findEnrollmentRequestByCourseIdAndUserId(UUID courseId, UUID userId);
 
 }

--- a/thryve-backend/src/main/java/bg/sofia/uni/fmi/webjava/backend/service/EnrollmentRequestService.java
+++ b/thryve-backend/src/main/java/bg/sofia/uni/fmi/webjava/backend/service/EnrollmentRequestService.java
@@ -1,0 +1,114 @@
+package bg.sofia.uni.fmi.webjava.backend.service;
+
+import bg.sofia.uni.fmi.webjava.backend.exception.EnrollmentRequestAlreadyFinalizedException;
+import bg.sofia.uni.fmi.webjava.backend.exception.EntityAlreadyExistsException;
+import bg.sofia.uni.fmi.webjava.backend.exception.EntityNotFoundException;
+import bg.sofia.uni.fmi.webjava.backend.mapper.EnrollmentRequestDtoMapper;
+import bg.sofia.uni.fmi.webjava.backend.model.dto.enrollment.CreateEnrollmentDto;
+import bg.sofia.uni.fmi.webjava.backend.model.dto.enrollment.request.EnrollmentRequestResponseDto;
+import bg.sofia.uni.fmi.webjava.backend.model.entity.Course;
+import bg.sofia.uni.fmi.webjava.backend.model.entity.EnrollmentRequest;
+import bg.sofia.uni.fmi.webjava.backend.model.entity.EnrollmentState;
+import bg.sofia.uni.fmi.webjava.backend.model.entity.User;
+import bg.sofia.uni.fmi.webjava.backend.repository.EnrollmentRequestRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+import static java.lang.String.format;
+
+@Service
+@RequiredArgsConstructor
+public class EnrollmentRequestService {
+
+    public static final String ENROLLMENT_REQUEST_NOT_FOUND_ERROR_MESSAGE = "Enrollment request with id %s was not found!";
+    public static final String ENROLLMENT_REQUEST_ALREADY_EXISTS_MESSAGE =
+        "Enrollment request for course with id %s and user with id %s not found!";
+    public static final String ENROLLMENT_REQUEST_ALREADY_FINALIZED_MESSAGE =
+        "Enrollment request with id %s is already in a final state!";
+
+    private final EnrollmentRequestRepository enrollmentRequestRepository;
+    private final EnrollmentRequestDtoMapper enrollmentRequestDtoMapper;
+    private final CourseService courseService;
+    private final UserService userService;
+    private final EnrollmentService enrollmentService;
+
+    @Transactional
+    public Page<EnrollmentRequestResponseDto> getEnrollmentsByCourseId(UUID courseId, Pageable pageable) {
+        return enrollmentRequestRepository.findEnrollmentRequestsByCourseId(courseId, pageable)
+            .map(enrollmentRequestDtoMapper::mapToResponseDto);
+    }
+
+    @Transactional
+    public Page<EnrollmentRequestResponseDto> getEnrollmentsByUserId(UUID userId, Pageable pageable) {
+        return enrollmentRequestRepository.findEnrollmentRequestsByUserId(userId, pageable)
+            .map(enrollmentRequestDtoMapper::mapToResponseDto);
+    }
+
+    @Transactional
+    protected EnrollmentRequest getEnrollmentRequestEntityById(UUID id) {
+        return enrollmentRequestRepository.findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(format(ENROLLMENT_REQUEST_NOT_FOUND_ERROR_MESSAGE, id)));
+    }
+
+    @Transactional
+    public EnrollmentRequestResponseDto createEnrollmentRequest(UUID courseId, UUID userId) {
+        if (enrollmentRequestRepository.findEnrollmentRequestByCourseIdAndUserId(courseId, userId).isPresent()) {
+            throw new EntityAlreadyExistsException(format(ENROLLMENT_REQUEST_ALREADY_EXISTS_MESSAGE, courseId, userId));
+        }
+
+        Course course = courseService.getCourseEntityById(courseId);
+        User user = userService.getUserEntityById(userId);
+
+        EnrollmentRequest request = new EnrollmentRequest();
+        request.setCourse(course);
+        request.setUser(user);
+
+        return enrollmentRequestDtoMapper.mapToResponseDto(enrollmentRequestRepository.save(request));
+    }
+
+    @Transactional
+    public EnrollmentRequestResponseDto acceptEnrollmentRequestById(UUID id) {
+        System.out.println("here");
+        EnrollmentRequest request = getEnrollmentRequestEntityById(id);
+        if (isEnrollmentRequestInFinalState(request)) {
+            throw new EnrollmentRequestAlreadyFinalizedException(
+                format(ENROLLMENT_REQUEST_ALREADY_FINALIZED_MESSAGE, request.getId()));
+        }
+        request.setState(EnrollmentState.ACCEPTED);
+
+        CreateEnrollmentDto createEnrollmentDto = new CreateEnrollmentDto();
+        createEnrollmentDto.setCourseId(request.getCourse().getId());
+        createEnrollmentDto.setUserId(request.getUser().getId());
+        enrollmentService.createEnrollment(createEnrollmentDto);
+
+        return enrollmentRequestDtoMapper.mapToResponseDto(enrollmentRequestRepository.save(request));
+    }
+
+    @Transactional
+    public EnrollmentRequestResponseDto rejectEnrollmentRequestById(UUID id) {
+        EnrollmentRequest request = getEnrollmentRequestEntityById(id);
+        if (isEnrollmentRequestInFinalState(request)) {
+            throw new EnrollmentRequestAlreadyFinalizedException(
+                format(ENROLLMENT_REQUEST_ALREADY_FINALIZED_MESSAGE, request.getId()));
+        }
+        request.setState(EnrollmentState.REJECTED);
+        return enrollmentRequestDtoMapper.mapToResponseDto(enrollmentRequestRepository.save(request));
+    }
+
+    private boolean isEnrollmentRequestInFinalState(EnrollmentRequest request) {
+        return request.getState() != EnrollmentState.PENDING;
+    }
+
+    @Transactional
+    public EnrollmentRequestResponseDto deleteEnrollmentRequestById(UUID id) {
+        EnrollmentRequest request = getEnrollmentRequestEntityById(id);
+        enrollmentRequestRepository.delete(request);
+        return enrollmentRequestDtoMapper.mapToResponseDto(request);
+    }
+
+}

--- a/thryve-backend/src/main/java/bg/sofia/uni/fmi/webjava/backend/service/EnrollmentService.java
+++ b/thryve-backend/src/main/java/bg/sofia/uni/fmi/webjava/backend/service/EnrollmentService.java
@@ -38,7 +38,8 @@ public class EnrollmentService {
     }
 
     @Transactional
-    public Page<EnrollmentResponseDto> getEnrollmentsByCourseIdAndUserId(UUID courseId, UUID userId, Pageable pageable) {
+    public Page<EnrollmentResponseDto> getEnrollmentsByCourseIdAndUserId(UUID courseId, UUID userId,
+                                                                         Pageable pageable) {
         return enrollmentRepository.findEnrollmentByCourseIdAndUserId(courseId, userId, pageable)
             .map(enrollmentDtoMapper::mapToResponseDto);
     }
@@ -56,11 +57,14 @@ public class EnrollmentService {
     }
 
     @Transactional
-    public EnrollmentResponseDto getEnrollmentById(UUID id) {
-        Enrollment enrollment = enrollmentRepository.findById(id)
+    protected Enrollment getEnrollmentEntityById(UUID id) {
+        return enrollmentRepository.findById(id)
             .orElseThrow(() -> new EntityNotFoundException(format(ENROLLMENT_NOT_FOUND_ERROR_MESSAGE, id)));
+    }
 
-        return enrollmentDtoMapper.mapToResponseDto(enrollment);
+    @Transactional
+    public EnrollmentResponseDto getEnrollmentById(UUID id) {
+        return enrollmentDtoMapper.mapToResponseDto(getEnrollmentEntityById(id));
     }
 
     @Transactional
@@ -78,9 +82,7 @@ public class EnrollmentService {
 
     @Transactional
     public EnrollmentResponseDto updateEnrollmentById(UUID id, UpdateEnrollmentDto updateEnrollmentDto) {
-        Enrollment enrollment = enrollmentRepository.findById(id)
-            .orElseThrow(() -> new EntityNotFoundException(format(ENROLLMENT_NOT_FOUND_ERROR_MESSAGE, id)));
-
+        Enrollment enrollment = getEnrollmentEntityById(id);
         enrollmentDtoMapper.updateEnrollmentFromDto(updateEnrollmentDto, enrollment);
         return enrollmentDtoMapper.mapToResponseDto(enrollmentRepository.save(enrollment));
     }

--- a/thryve-backend/src/main/java/bg/sofia/uni/fmi/webjava/backend/service/UserService.java
+++ b/thryve-backend/src/main/java/bg/sofia/uni/fmi/webjava/backend/service/UserService.java
@@ -72,10 +72,7 @@ public class UserService {
 
     @Transactional
     public UserResponseDto updateUserById(UUID id, UpdateUserDto updateUserDto) {
-        User user = userRepository.findById(id).orElseThrow(
-            () -> new EntityNotFoundException(
-                format(USER_NOT_FOUND_ERROR_MESSAGE, id)));
-
+        User user = getUserEntityById(id);
         userDtoMapper.updateUserFromDto(updateUserDto, user);
         return userDtoMapper.mapUserToResponseDto(userRepository.save(user));
     }


### PR DESCRIPTION
Implemented the following endpoints:
- GET /api/courses/{courseId}/enrollment-requests
- GET /api/users/{userId}/enrollment-requests
- POST /api/enrollment-requests
- POST /api/enrollment-requests/{id}/accept
- POST /api/enrollment-requests/{id}/reject
- DELETE /api/enrollment-requests/{id}

Also made some adjustments to already existing logic, and added createdAt and modifiedAt fields for every entity, on pre-persist and pre-update.